### PR TITLE
feat: switch from kube-prometheus-stack chart to prometheus chart

### DIFF
--- a/sre/group_vars/observability_tools.yaml
+++ b/sre/group_vars/observability_tools.yaml
@@ -18,10 +18,9 @@ es_chart_version: "21.4.5"
 
 # Prometheus - Grafana configuration
 prometheus_namespace_project_name: "prometheus"
-prometheus_installation_name: "prometheus-stack"
-prometheus_chart_version: "69.3.1"
-prometheus_service_name: "prometheus-stack-kube-prom-prometheus"
-prometheus_alertmanager_service_name: "prometheus-stack-kube-prom-alertmanager"
+prometheus_installation_name: "prometheus"
+prometheus_chart_version: "27.5.1"
+prometheus_service_name: "prometheus-server"
 
 # Granfana configuration
 grafana_namespace_project_name: "grafana"

--- a/sre/group_vars/observability_tools.yaml
+++ b/sre/group_vars/observability_tools.yaml
@@ -19,7 +19,7 @@ es_chart_version: "21.4.5"
 # Prometheus - Grafana configuration
 prometheus_namespace_project_name: "prometheus"
 prometheus_installation_name: "prometheus"
-prometheus_chart_version: "27.5.1"
+prometheus_chart_version: "27.8.0"
 prometheus_service_name: "prometheus-server"
 
 # Granfana configuration

--- a/sre/roles/book_keeping/tasks/leverage_ingress.yaml
+++ b/sre/roles/book_keeping/tasks/leverage_ingress.yaml
@@ -1,18 +1,18 @@
 ---
-- name: Get the Ingress URL of Grafana
-  ansible.builtin.shell: "KUBECONFIG={{ kubeconfig }} kubectl get ingress grafana -n {{ grafana_namespace_project_name }} -o json"
-  register: grafana_ingress
+- name: Get the Ingress URL of Prometheus
+  ansible.builtin.shell: "KUBECONFIG={{ kubeconfig }} kubectl get ingress prometheus -n {{ prometheus_namespace_project_name }} -o json"
+  register: prometheus_ingress
   retries: 5
   delay: 60
-  until: (grafana_ingress.stdout | length) > 0
+  until: (prometheus_ingress.stdout | length) > 0
   ignore_errors: yes
 
 - name: Extract the Ingress hostname information
   set_fact:
-    ingress_hostname: "{{ grafana_ingress.stdout | from_json | json_query('status.loadBalancer.ingress[0].hostname') }}"
-  when: grafana_ingress.stdout | trim != ''
+    ingress_hostname: "{{ prometheus_ingress.stdout | from_json | json_query('status.loadBalancer.ingress[0].hostname') }}"
+  when: prometheus_ingress.stdout | trim != ''
 
-- name: Set the Grafana URL
+- name: Set the Prometheus URL
   set_fact:
-    grafana_url: "http://{{ ingress_hostname }}/grafana"
+    prometheus_url: "http://{{ ingress_hostname }}/prometheus"
   when: ingress_hostname is defined and ingress_hostname | trim != ''

--- a/sre/roles/book_keeping/tasks/main.yaml
+++ b/sre/roles/book_keeping/tasks/main.yaml
@@ -33,7 +33,7 @@
 
 - name: Call the alerts API
   uri:
-    url: "{{ grafana_url }}/api/prometheus/grafana/api/v1/alerts"
+    url: "{{ prometheus_url }}/api/v1/alerts"
     method: GET
     return_content: yes
     body_format: json

--- a/sre/roles/bundle_info/tasks/main.yaml
+++ b/sre/roles/bundle_info/tasks/main.yaml
@@ -1,13 +1,13 @@
 ---
-- name: Get the Ingress URL of Grafana
-  ansible.builtin.shell: "KUBECONFIG={{ kubeconfig }} kubectl get ingress grafana -n {{ grafana_namespace_project_name }} -o json"
-  register: grafana_ingress
+- name: Get the Ingress URL of Prometheus
+  ansible.builtin.shell: "KUBECONFIG={{ kubeconfig }} kubectl get ingress prometheus -n {{ prometheus_namespace_project_name }} -o json"
+  register: prometheus_ingress
   tags:
     - get_bundle_info
 
 - name: Construct the alerts API URI
   set_fact:
-    alerts_api_url: "http://{{ grafana_ingress.stdout | from_json | json_query('status.loadBalancer.ingress[0].hostname') }}/{{ grafana_namespace_project_name }}"
+    alerts_api_url: "http://{{ prometheus_ingress.stdout | from_json | json_query('status.loadBalancer.ingress[0].hostname') }}/{{ prometheus_namespace_project_name }}"
   tags:
     - get_bundle_info
 
@@ -33,12 +33,12 @@
   register: kubeconfig_output
   tags:
     - get_bundle_info
-    
-- name: Return grafana url
+
+- name: Return Prometheus url
   debug:
-    msg: > 
+    msg: >
       {{ {
-          'grafana_url': (alerts_api_url),
+          'prometheus_url': (alerts_api_url),
           'kubeconfig': (kubeconfig_output.stdout)
         } }}
   tags:

--- a/sre/roles/evaluation/tasks/fetch_alerts.yaml
+++ b/sre/roles/evaluation/tasks/fetch_alerts.yaml
@@ -1,13 +1,13 @@
 ---
 - name: Get the Ingress URL of Grafana
-  ansible.builtin.shell: "KUBECONFIG={{ kubeconfig }} kubectl get ingress grafana -n {{ grafana_namespace_project_name }} -o json"
+  ansible.builtin.shell: "KUBECONFIG={{ kubeconfig }} kubectl get ingress prometheus -n {{ prometheus_namespace_project_name }} -o json"
   register: grafana_ingress
   tags:
     - fetch_alerts
 
 - name: Construct the alerts API URI
   set_fact:
-    alerts_api_url: "http://{{ grafana_ingress.stdout | from_json | json_query('status.loadBalancer.ingress[0].hostname') }}/{{ grafana_namespace_project_name }}/api/prometheus/grafana/api/v1/alerts"
+    alerts_api_url: "http://{{ grafana_ingress.stdout | from_json | json_query('status.loadBalancer.ingress[0].hostname') }}/{{ prometheus_namespace_project_name }}/api/v1/alerts"
   tags:
     - fetch_alerts
 
@@ -15,10 +15,10 @@
   command: >
     python3 roles/evaluation/sre_evaluation/alertsdump.py
     --url="{{ alerts_api_url }}"
-    --alertsfilepath="{{ alertsfilepath }}" 
-    --pollinginterval="{{ pollinginterval }}" 
-    --active_alert_wait_time="{{ wait_time }}" 
+    --alertsfilepath="{{ alertsfilepath }}"
+    --pollinginterval="{{ pollinginterval }}"
+    --active_alert_wait_time="{{ wait_time }}"
     --incidentno="{{ incident_number }}"
-  when:  alerts_api_url is defined 
+  when:  alerts_api_url is defined
   tags:
     - fetch_alerts

--- a/sre/roles/fault_injection/tasks/run_missing_storageclass.yaml
+++ b/sre/roles/fault_injection/tasks/run_missing_storageclass.yaml
@@ -35,7 +35,7 @@
     dest: roles/sample_applications/DeathStarBench
     single_branch: yes
     version: master
-  when: 
+  when:
     - dsb_dir_status is defined and dsb_dir_status.stat is defined and not (dsb_dir_status.stat.exists)
     - is_fault_injection or is_fault_removal
     - is_missing_storage_class
@@ -50,7 +50,7 @@
   ansible.builtin.copy:
     src: roles/sample_applications/DeathStarBench/hotelReservation/helm-chart/hotelreservation/values.yaml
     dest: roles/sample_applications/DeathStarBench/hotelReservation/helm-chart/hotelreservation/values.yaml.bak
-  when: 
+  when:
     - bak_file_status is defined and bak_file_status.stat is defined and not bak_file_status.stat.exists
     - is_fault_injection
     - is_missing_storage_class
@@ -96,7 +96,7 @@
           environments:
             MEMCACHED_CACHE_SIZE: "128"
             MEMCACHED_THREADS: "2"
-      
+
         mongodb:
           persistentVolume:               # use hostPath or pvprovisioner
             enabled: true
@@ -109,7 +109,7 @@
               storageClassName: ceph-fs   # an non-existent storageclass
   when: is_fault_injection and is_missing_storage_class
 
-- name: Deploy Deathstar Hotel Reservations 
+- name: Deploy Deathstar Hotel Reservations
   kubernetes.core.helm:
     name: "{{ deathstarbench_hotelreservation_app_installation_name }}"
     kubeconfig_path: "{{ kubeconfig }}"
@@ -125,7 +125,7 @@
         value_type: raw
       - value: "global.monitoring.centralJaegerAddress={{ jaeger_installation_name }}-collector.{{ jaeger_namespace_project_name }}.svc.cluster.local"
         value_type: raw
-      - value: "global.monitoring.centralPrometheusAddress=http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}:9090/api/v1/otlp"
+      - value: "global.monitoring.centralPrometheusAddress=http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}.svc.cluster.local:80/api/v1/otlp"
         value_type: raw
       - value: "global.nameOverride={{ deathstarbench_hotelreservation_app_installation_name }}"
         value_type: raw
@@ -139,12 +139,12 @@
   ansible.builtin.copy:
     src: roles/sample_applications/DeathStarBench/hotelReservation/helm-chart/hotelreservation/values.yaml.bak
     dest: roles/sample_applications/DeathStarBench/hotelReservation/helm-chart/hotelreservation/values.yaml
-  when: 
+  when:
     - bak_file_status is defined and bak_file_status.stat is defined and not bak_file_status.stat.exists
-    - is_fault_removal 
+    - is_fault_removal
     - is_missing_storage_class
 
-- name: Deploy Deathstar Hotel Reservations 
+- name: Deploy Deathstar Hotel Reservations
   kubernetes.core.helm:
     name: "{{ deathstarbench_hotelreservation_app_installation_name }}"
     kubeconfig_path: "{{ kubeconfig }}"
@@ -160,7 +160,7 @@
         value_type: raw
       - value: "global.monitoring.centralJaegerAddress={{ jaeger_installation_name }}-collector.{{ jaeger_namespace_project_name }}.svc.cluster.local"
         value_type: raw
-      - value: "global.monitoring.centralPrometheusAddress=http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}:9090/api/v1/otlp"
+      - value: "global.monitoring.centralPrometheusAddress=http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}.svc.cluster.local:80/api/v1/otlp"
         value_type: raw
       - value: "global.nameOverride={{ deathstarbench_hotelreservation_app_installation_name }}"
         value_type: raw

--- a/sre/roles/observability_tools/tasks/install_elasticsearch.yaml
+++ b/sre/roles/observability_tools/tasks/install_elasticsearch.yaml
@@ -13,6 +13,7 @@
     values:
       master:
         replicaCount: 1
+        heapSize: 384m
         persistence:
           size: "8Gi"
       data:

--- a/sre/roles/observability_tools/tasks/install_jaeger.yaml
+++ b/sre/roles/observability_tools/tasks/install_jaeger.yaml
@@ -25,7 +25,7 @@
       prometheus:
         query:
           support-spanmetrics-connector: true
-        server-url: "http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}:9090"
+        server-url: "http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}.svc.cluster.local:80"
       provisionDataStore:
         cassandra: false
       query:

--- a/sre/roles/observability_tools/tasks/install_opencost.yaml
+++ b/sre/roles/observability_tools/tasks/install_opencost.yaml
@@ -35,7 +35,7 @@
         prometheus:
           external:
             enabled: true
-            url: "http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}:9090"
+            url: "http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}.svc.cluster.local:80"
           internal:
             enabled: false
         ui:

--- a/sre/roles/observability_tools/tasks/install_prometheus.yaml
+++ b/sre/roles/observability_tools/tasks/install_prometheus.yaml
@@ -30,7 +30,42 @@
           - web.enable-lifecycle
           - web.enable-otlp-receiver
       serverFiles:
+        alerting_rules.yml: {}
         recording_rules.yml:
           groups: "{{ prometheus_rules }}"
       prometheus-pushgateway:
         enabled: false
+
+- name: Deploy Ingress for Prometheus and AlertManager frontends
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig }}"
+    resource_definition:
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: prometheus
+        namespace: "{{ prometheus_namespace_project_name }}"
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: /$2
+      spec:
+        ingressClassName: nginx
+        rules:
+          - http:
+              paths:
+                - pathType: ImplementationSpecific
+                  path: /prometheus(/|$)(.*)
+                  backend:
+                    service:
+                      name: "{{ prometheus_installation_name }}-server"
+                      port:
+                        number: 80
+          - http:
+              paths:
+                - pathType: ImplementationSpecific
+                  path: /alertmanager(/|$)(.*)
+                  backend:
+                    service:
+                      name: "{{ prometheus_installation_name }}-alertmanager"
+                      port:
+                        number: 9093

--- a/sre/roles/observability_tools/tasks/install_prometheus.yaml
+++ b/sre/roles/observability_tools/tasks/install_prometheus.yaml
@@ -1,19 +1,35 @@
 ---
-- name: Create Prometheus rules list
-  set_fact:
-    prometheus_rules: []
+- name: Set additional template variables
+  ansible.builtin.set_fact:
+    enable_finops_rules: "{{ domain == 'finops' }}"
 
-- name: Load OpenCost recording rules from yaml
-  set_fact:
-    opencost_recording_rules: "{{ lookup('ansible.builtin.file', 'files/recording_rules_opencost.yaml')| from_yaml }}"
-  when:
-    - domain == "finops"
+- name: Copy alerting rules template into tmp directory for processing
+  ansible.builtin.copy:
+    src: templates/prometheus-alerting-rules.j2
+    dest: /tmp/prometheus-alerting-rules.j2
 
-- name: Add OpenCost rules to Prometheus rules list
-  set_fact:
-    prometheus_rules: "{{ prometheus_rules + opencost_recording_rules }}"
-  when:
-    - domain == "finops"
+- name: Create a temporary template with fake curly brackets for processing
+  ansible.builtin.replace:
+    path: /tmp/prometheus-alerting-rules.j2
+    regexp: "\\{\\{([a-zA-Z\\.$_ ]*)\\}\\}"
+    replace: "<<\\1>>"
+
+- name: Create new alerting rules template from proccesed template
+  ansible.builtin.copy:
+    dest: /tmp/prometheus-required-alerting-rules.j2
+    content: "{{ lookup('ansible.builtin.template', '/tmp/prometheus-alerting-rules.j2') }}"
+
+- name: Escape double curly brackets in alerting rules yaml file
+  ansible.builtin.replace:
+    path: /tmp/prometheus-required-alerting-rules.j2
+    regexp: "<<([a-zA-Z\\.$_ ]*)>>"
+    replace: "\\{\\{\"\\{\\{\"\\}\\}\\1\\{\\{\"\\}\\}\"\\}\\}"
+
+- name: Remove double backslash in alerting rules yaml file
+  ansible.builtin.replace:
+    path: /tmp/prometheus-required-alerting-rules.j2
+    regexp: "\\\\"
+    replace: ""
 
 - name: Deploy the Prometheus stack
   kubernetes.core.helm:
@@ -30,9 +46,8 @@
           - web.enable-lifecycle
           - web.enable-otlp-receiver
       serverFiles:
-        alerting_rules.yml: {}
-        recording_rules.yml:
-          groups: "{{ prometheus_rules }}"
+        alerting_rules.yml: "{{ lookup('ansible.builtin.template', '/tmp/prometheus-required-alerting-rules.j2') | from_yaml }}"
+        recording_rules.yml: "{{ lookup('ansible.builtin.template', 'templates/prometheus-recording-rules.j2') | from_yaml }}"
       prometheus-pushgateway:
         enabled: false
 

--- a/sre/roles/observability_tools/tasks/install_prometheus.yaml
+++ b/sre/roles/observability_tools/tasks/install_prometheus.yaml
@@ -19,30 +19,18 @@
   kubernetes.core.helm:
     name: "{{ prometheus_installation_name }}"
     kubeconfig_path: "{{ kubeconfig }}"
-    chart_ref: prometheus-community/kube-prometheus-stack 
+    chart_ref: prometheus-community/prometheus
     chart_version: "{{ prometheus_chart_version }}"
     release_namespace: "{{ prometheus_namespace_project_name }}"
     release_state: present
     create_namespace: true
     values:
-      additionalPrometheusRulesMap:
-        rule-name:
+      server:
+        extraFlags:
+          - web.enable-lifecycle
+          - web.enable-otlp-receiver
+      serverFiles:
+        recording_rules.yml:
           groups: "{{ prometheus_rules }}"
-      alertmanager:
-        ingress:
-          enabled: true
-      grafana:
+      prometheus-pushgateway:
         enabled: false
-      prometheus:
-        enabled: true
-        prometheusSpec:
-          additionalArgs:
-            - name: web.enable-otlp-receiver
-              value: ""
-          defaultRules:
-            additionalRuleLabels:
-              - for_instance_in_namespace: "{{ prometheus_namespace_project_name }}"
-          enableFeatures:
-            - otlp-write-receiver
-          podMonitorSelectorNilUsesHelmValues: false
-          serviceMonitorSelectorNilUsesHelmValues: false

--- a/sre/roles/observability_tools/templates/datasource_prometheus.j2
+++ b/sre/roles/observability_tools/templates/datasource_prometheus.j2
@@ -2,12 +2,12 @@
   uid: prometheus
   type: prometheus
   access: proxy
-  url: http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}:9090
+  url: http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}.svc.cluster.local:80
   user: ""
   database: ""
   basicAuth: false
   isDefault: false
-  jsonData: 
+  jsonData:
     httpMethod: POST
     timeInterval: 30s
     tlsAuth: false
@@ -15,7 +15,7 @@
 - name: Alertmanager
   type: alertmanager
   uid: alertmanager
-  url: http://{{ prometheus_alertmanager_service_name }}.{{ prometheus_namespace_project_name }}:9093
+  url: http://prometheus-alertmanager.{{ prometheus_namespace_project_name }}.svc.cluster.local:9093
   access: proxy
   jsonData:
     handleGrafanaManagedAlerts: false

--- a/sre/roles/observability_tools/templates/prometheus-alerting-rules.j2
+++ b/sre/roles/observability_tools/templates/prometheus-alerting-rules.j2
@@ -19,7 +19,7 @@ groups:
         expr: histogram_quantile(0.95, sum by(le, service_name, namespace) (rate(traces_span_metrics_duration_milliseconds_bucket{service_name!~"flagd|otel-demo-loadgenerator"}[2m]))) > 1500
         for: 1m
         annotations:
-          description: 'Latency in service {{ $labels.service_name }} in namespace {{ $labels.namespace }} is above 1500s (current value: {{ $value }}s)'
+          description: 'Latency in service {{ $labels.service_name }} in namespace {{ $labels.namespace }} is above 1500ms (current value: {{ $value }}s)'
           summary: High latency detected in service {{ $labels.service_name }} in namespace {{ $labels.namespace }}.
       - alert: HighRequestErrorRate
         expr: sum by (service_name, namespace) (delta(traces_span_metrics_calls_total{status_code="STATUS_CODE_ERROR", service_name!~"flagd|otel-demo-loadgenerator"}[2m])) > 0

--- a/sre/roles/observability_tools/templates/prometheus-alerting-rules.j2
+++ b/sre/roles/observability_tools/templates/prometheus-alerting-rules.j2
@@ -1,0 +1,70 @@
+groups:
+  - name: ClusterAlerts
+    interval: 1m
+    rules:
+      - alert: HighPodFailureCount
+        expr: sum by(namespace) (kube_pod_status_phase{phase="Failed"}) > 0
+        annotations:
+          description: 'Failure pod count in namespace {{ $labels.namespace }} is above 0 (current value: {{ $value }})'
+          summary: High pod failure count detected in namespace {{ $labels.namespace }}.
+      - alert: HighPodPendingCount
+        expr: sum by(namespace) (kube_pod_status_phase{phase="Pending"}) > 0
+        annotations:
+          description: 'Pending pod count in namespace {{ $labels.namespace }} is above 0 (current value: {{ $value }})'
+          summary: High pod pending count detected in namespace {{ $labels.namespace }}.
+  - name: GoldenSignalAlerts
+    interval: 1m
+    rules:
+      - alert: HighRequestLatency
+        expr: histogram_quantile(0.95, sum by(le, service_name, namespace) (rate(traces_span_metrics_duration_milliseconds_bucket{service_name!~"flagd|otel-demo-loadgenerator"}[2m]))) > 1500
+        for: 1m
+        annotations:
+          description: 'Latency in service {{ $labels.service_name }} in namespace {{ $labels.namespace }} is above 1500s (current value: {{ $value }}s)'
+          summary: High latency detected in service {{ $labels.service_name }} in namespace {{ $labels.namespace }}.
+      - alert: HighRequestErrorRate
+        expr: sum by (service_name, namespace) (delta(traces_span_metrics_calls_total{status_code="STATUS_CODE_ERROR", service_name!~"flagd|otel-demo-loadgenerator"}[2m])) > 0
+        for: 1m
+        annotations:
+          description: 'Request error rate in service {{ $labels.service_name }} in namespace {{ $labels.namespace }} is above 0 (current value: {{ $value }})'
+          summary: Error rate is too high for service {{ $labels.service_name }} in namespace {{ $labels.namespace }}.
+  - name: KafkaAlerts
+    interval: 1m
+    rules:
+      - alert: HighKafkaConnectionClosureRate
+        expr: sum by (job) (kafka_consumer_connection_close_rate) > 0
+        for: 1m
+        annotations:
+          description: 'Job {{ $labels.job }} has a high closure rate above 0 (current value: {{ $value }})'
+          summary: High connection closure rate detected in job {{ $labels.job }}.
+{% if enable_finops_rules %}
+  - name: AstronomyShopCostAlerts
+    interval: 1m
+    rules:
+      - alert: HighCPUSpend
+        expr: sum by (exported_namespace) (exported_container_exported_namespace_node:container_cpu_allocation_cost_per_node:avg5m{exported_container!="loadgenerator", exported_namespace="otel-demo"}) > 0.03
+        for: 1m
+        annotations:
+          description: '{{ $labels.exported_namespace }} has exceeded the allocated budget for vCPU for 5m (current value: ${{ $value }})'
+          summary: Overspend for vCPU detected in {{ $labels.exported_namespace }}.
+      - alert: HighMemorySpend
+        expr: sum by (exported_namespace) (exported_container_exported_namespace_node:container_memory_allocation_gigabytes_cost_per_node:avg5m{exported_container!="loadgenerator", exported_namespace="otel-demo"}) > 0.009
+        for: 1m
+        annotations:
+          description: '{{ $labels.exported_namespace }} has exceeded the allocated budget for RAM for 5m (current value: ${{ $value }})'
+          summary: Overspend for RAM detected in {{ $labels.exported_namespace }}.
+  - name: AstronomyShopEfficiencyAlerts
+    interval: 1m
+    rules:
+      - alert: LowCPUEfficiency
+        expr: avg by (container, namespace) (container_namespace:container_cpu_usage_seconds_per_requests:ratio_irate5m{container!="loadgenerator", namespace="otel-demo"}) * 100 < 85
+        for: 1m
+        annotations:
+          description: '{{ $labels.container }} in {{ $labels.namespace }} has a cpu efficiency below 85% for 5m (current value: {{ $value }}%)'
+          summary: Low vCPU efficiency detected in {{ $labels.container }}.
+      - alert: LowMemoryEfficiency
+        expr: avg by (container, namespace) (container_namespace:container_memory_working_set_bytes_per_requests_bytes:ratio_avg5m{container!="loadgenerator", namespace="otel-demo"}) * 100 < 70
+        for: 1m
+        annotations:
+          description: '{{ $labels.container }} in {{ $labels.namespace }} has a memory efficiency below 70% for 5m (current value: {{ $value }}%)'
+          summary: Low memory efficiency detected in {{ $labels.container }}.
+{% endif %}

--- a/sre/roles/observability_tools/templates/prometheus-recording-rules.j2
+++ b/sre/roles/observability_tools/templates/prometheus-recording-rules.j2
@@ -1,0 +1,59 @@
+groups:
+  - name: workload.efficiency
+    rules:
+      - record: container_namespace:container_cpu_usage_seconds_per_requests:ratio_irate5m
+        expr: |
+          sum (
+            irate(
+              container_cpu_usage_seconds_total{container=~".+"}[5m]
+            )
+          ) by(container, namespace)
+          /
+          sum (
+            avg_over_time(
+              kube_pod_container_resource_requests{container=~".+", resource="cpu"}[5m]
+            )
+          ) by(container, namespace)
+      - record: container_namespace:container_memory_working_set_bytes_per_requests_bytes:ratio_avg5m
+        expr: |
+          sum (
+            avg_over_time(
+              container_memory_working_set_bytes{container=~".+"}[5m]
+            )
+          ) by(container, namespace)
+          /
+          sum (
+            avg_over_time(
+              kube_pod_container_resource_requests{container=~".+", resource="memory"}[5m]
+            )
+          ) by(container, namespace)
+{% if enable_finops_rules %}
+  - name: opencost.rules
+    rules:
+      - record: exported_container_exported_namespace_node:container_cpu_allocation_cost_per_node:avg5m
+        expr: |
+          sum (
+            avg_over_time(
+              container_cpu_allocation[5m]
+            )
+          ) by(exported_container, exported_namespace, node)
+          * on (node) group_left
+          sum (
+            avg_over_time(
+              node_cpu_hourly_cost[5m]
+            )
+          ) by(node)
+      - record: exported_container_exported_namespace_node:container_memory_allocation_gigabytes_cost_per_node:avg5m
+        expr: |
+          sum (
+            avg_over_time(
+              container_memory_allocation_bytes[5m]
+            ) / 1024 / 1024 / 1024
+          ) by(exported_container, exported_namespace, node)
+          * on (node) group_left
+          sum (
+            avg_over_time(
+              node_ram_hourly_cost[5m]
+            )
+          ) by(node)
+{% endif %}

--- a/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
+++ b/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
@@ -130,7 +130,6 @@
             requests:
               cpu: 50m
               memory: 15Mi
-          resources:
             limits:
               memory: 32Mi
         quoteService:

--- a/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
+++ b/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
@@ -140,7 +140,7 @@
               memory: 100Mi
         shippingService:
           resources:
-            requests: 
+            requests:
               cpu: 10m
               memory: 10Mi
         valkey:
@@ -168,7 +168,7 @@
             otlp:
               endpoint: "{{ jaeger_installation_name }}-collector.{{ jaeger_namespace_project_name }}.svc.cluster.local:4317"
             otlphttp/prometheus:
-              endpoint: "http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}:9090/api/v1/otlp"
+              endpoint: http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}.svc.cluster.local:80/api/v1/otlp
         resources:
           requests:
             cpu: 100m

--- a/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
+++ b/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
@@ -56,6 +56,8 @@
             requests:
               cpu: 10m
               memory: 15Mi
+            limits:
+              memory: 32Mi
         currencyService:
           resources:
             requests:
@@ -128,6 +130,9 @@
             requests:
               cpu: 50m
               memory: 15Mi
+          resources:
+            limits:
+              memory: 32Mi
         quoteService:
           resources:
             requests:

--- a/sre/roles/sample_applications/tasks/install_deathstarbench_hotel_reservation.yaml
+++ b/sre/roles/sample_applications/tasks/install_deathstarbench_hotel_reservation.yaml
@@ -21,7 +21,7 @@
       global:
         monitoring:
           centralJaegerAddress: "{{ jaeger_installation_name }}-collector.{{ jaeger_namespace_project_name }}.svc.cluster.local"
-          centralPrometheusAddress: "http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}:9090/api/v1/otlp"
+          centralPrometheusAddress: "http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}.svc.cluster.local:80/api/v1/otlp"
           defaultJaegerEnabled: false
           otelAddress: "otel-collector-{{ deathstarbench_hotelreservation_app_installation_name }}.{{ deathstarbench_hotelreservation_app_namespace_project_name }}.svc.cluster.local"
         nameOverride: "{{ deathstarbench_hotelreservation_app_installation_name }}"


### PR DESCRIPTION
This PR changes the Prometheus Helm chart from the community's `kube-prometheus-stack` (which deploys the Prometheus Operator to manage a Prometheus instance) to `prometheus`. This removes the operator, which would not be necessary considering the short nature of the benchmarks.