### PR TITLE
feat: add dependabot updates for Docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directories:
+      - sre/tools/**/*
+    schedule:
+      interval: daily

--- a/sre/tools/elasticsearch-dummy-app/Dockerfile
+++ b/sre/tools/elasticsearch-dummy-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-312
+FROM registry.access.redhat.com/ubi9/python-312:9.5-1743091356
 
 WORKDIR /app
 

--- a/sre/tools/kubernetes-topology-mapper/Dockerfile
+++ b/sre/tools/kubernetes-topology-mapper/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-312
+FROM registry.access.redhat.com/ubi9/python-312:9.5-1743091356
 
 ENV DATA_DIRECTORY /app/topology_data
 


### PR DESCRIPTION
This PR adds Dependabot updates for the Docker images used by SRE scenarios.