### PR TITLE
fix: apply grouping to dependabot docker pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,8 @@ updates:
   - package-ecosystem: docker
     directories:
       - sre/tools/**/*
+    groups:
+      docker-images-production:
+        applies-to: version-updates
     schedule:
       interval: daily


### PR DESCRIPTION
This is a follow up PR to #25 so that the PRs are combined into one rather than individually.