### PR TITLE
feat: add Dependabot for python and golang dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,54 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directories:
+      - /
+    groups:
+      actions-production-dependencies:
+        applies-to: version-updates
+        dependency-type: production
+    schedule:
+      interval: daily
+
   - package-ecosystem: docker
     directories:
       - sre/tools/**/*
     groups:
       docker-images-production:
         applies-to: version-updates
+        dependency-type: development
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: gomod
+    directories:
+      - sre/local_cluster
+    groups:
+      golang-tool-development-dependencies:
+        applies-to: version-updates
+        dependency-type: development
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directories:
+      - /
+      - sre/remote_cluster/
+    groups:
+      pip-development-dependecies:
+        applies-to: version-updates
+        dependency-type: development
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directories:
+      - sre/
+      - sre/tools/**/*
+    groups:
+      pip-production-dependecies:
+        applies-to: security-updates
+        dependency-type: production
     schedule:
       interval: daily
+    open-pull-requests-limit: 0

--- a/sre/tools/elasticsearch-dummy-app/Dockerfile
+++ b/sre/tools/elasticsearch-dummy-app/Dockerfile
@@ -2,7 +2,8 @@ FROM registry.access.redhat.com/ubi9/python-312:9.5-1743509868
 
 WORKDIR /app
 
-RUN pip install elasticsearch
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY es_dummy_app.py es_dummy_app.py
 

--- a/sre/tools/elasticsearch-dummy-app/requirements.txt
+++ b/sre/tools/elasticsearch-dummy-app/requirements.txt
@@ -1,0 +1,1 @@
+elasticsearch==8.17.2


### PR DESCRIPTION
Continuing #25 by adding the rest of the package ecosystems for SRE Scenarios.