### PR TITLE
fix: update Astronomy Shop resource limits to avoid OOM errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ These scenarios simulate compliance-related misconfigurations. Each scenario pro
 - A pre-configured environment with specific compliance issues
 - Tools to detect misconfigurations
 - Validation methods to verify successful remediation
+
 CISO scenarios are located [here](./ciso).
 
 ## [SRE Scenarios](./sre)
@@ -21,11 +22,13 @@ These scenarios focus on observability and incident response. Each scenario incl
   - Kubernetes events exporter
 - Simulated faults that trigger service degradation
 - Thereby leading to alerts associated with application performance issues such as increased error rates and latency spikes
-  SRE scenarios are located [here](./sre).
+
+SRE scenarios are located [here](./sre).
 
 ## [FinOps Scenarios](./sre)
 Each scenario includes:
 - The core SRE observability stack
 - OpenCost integration for cost monitoring
 - Simulated faults trigger cost overrun alerts
- FinOps scenarios are located [here](./sre) along-side SRE scenarios.
+
+FinOps scenarios are located [here](./sre) along-side SRE scenarios.

--- a/sre/base.yaml
+++ b/sre/base.yaml
@@ -28,7 +28,7 @@
 
     - name: Parse helm version
       ansible.builtin.set_fact:
-        system_helm_version: "{{ raw_helm_version_out.stdout_lines[0] | regex_search('v([0-9.]+).*', '\\1') | first }}"
+        system_helm_version: "{{ raw_helm_version_out.stdout_lines[0] | regex_search('([0-9]+\\.[0-9]+\\.[0-9]+).*', '\\1') | first }}"
       tags:
         - always
 

--- a/sre/local_cluster/README.md
+++ b/sre/local_cluster/README.md
@@ -7,7 +7,7 @@ _Note: The following setup guide presumes that the required software listed [her
 ## Recommended Software
 
 1. [Podman](https://podman.io/)
-2. [Golang](https://go.dev/)
+2. [Golang - v1.24 and above](https://go.dev/)
 2. [Kind](https://kind.sigs.k8s.io/)
 3. [Cloud Provider Kind](https://github.com/kubernetes-sigs/cloud-provider-kind)
 

--- a/sre/local_cluster/README_RHEL.md
+++ b/sre/local_cluster/README_RHEL.md
@@ -10,7 +10,7 @@ _Note: The following setup guide presumes that the required software listed [her
 
 1. [make] -- Ensure you have `make` installed or install it via `sudo dnf install make`
 2. [lsof] -- Ensure you have `lsof` installed or install it via `sudo dnf install lsof`
-3. [Go] -- Ensure you have `go` installed or install it by following the instructions [here](https://go.dev/doc/install)
+3. [Golang - v1.24 and above] -- Ensure you have `go` installed or install it by following the instructions [here](https://go.dev/doc/install)
 4. [Docker](https://www.docker.com/) -- See the next sub-section for installation details
 5. [Kind](https://kind.sigs.k8s.io/) -- See the next sub-section for installation details
 6. [Cloud-Provider-Kind](https://github.com/kubernetes-sigs/cloud-provider-kind) -- See the next sub-section for installation details

--- a/sre/roles/observability_tools/tasks/install_elasticsearch.yaml
+++ b/sre/roles/observability_tools/tasks/install_elasticsearch.yaml
@@ -19,6 +19,9 @@
         replicaCount: 1
         persistence:
           size: "8Gi"
+        resources:
+          limits:
+            memory: "3Gi"
       coordinating:
         replicaCount: 1
       ingest:

--- a/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
+++ b/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
@@ -37,11 +37,15 @@
             requests:
               cpu: 10m
               memory: 100Mi
+            limits:
+              memory: 256Mi
         adService:
           resources:
             requests:
               cpu: 10m
               memory: 250Mi
+            limits:
+              memory: 512Mi
         cartService:
           resources:
             requests:
@@ -81,6 +85,8 @@
             requests:
               cpu: 25m
               memory: 300Mi
+            limits:
+              memory: 512Mi
         frontend:
           resources:
             requests:
@@ -98,6 +104,8 @@
             requests:
               cpu: 25m
               memory: 550Mi
+            limits:
+              memory: 800Mi
         loadgenerator:
           imageOverride:
             repository: quay.io/it-bench/loadgenerator

--- a/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
+++ b/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
@@ -112,7 +112,7 @@
             tag: "0.3"
           resources:
             limits:
-              memory: 1500Mi
+              memory: 2048Mi
         imageprovider:
           resources:
             requests:


### PR DESCRIPTION
while running locally on Kind clusters on both Mac (arm64) and Linux (amd64). OOMKilled was being observed even before a fault was injected. Also added the requirement to have GoLang v1.24 and above for the local cluster setup. Anything below does not work as the `tool` directive is only supported in Golang v1.24 and above.