### PR TITLE
chore: sync precommit commitizen version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
     stages:
     - pre-push
   repo: https://github.com/commitizen-tools/commitizen
-  rev: v4.4.1
+  rev: v4.5.0


### PR DESCRIPTION
This PR is a followup form #41 . It updates the `pre-commit` configuration to use the same  version of `commitizen`.