### PR TITLE
fix: correct directory location of CISO scenarios Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: docker
     directories:
       - sre/tools/**/
-      - ciso/Dockerfile
+      - ciso/
     schedule:
       interval: weekly
 


### PR DESCRIPTION
This is a follow up PR to #40 . This corrects the directory details for Dependabot to scan the CISO scenario's Dockerfile.