### PR TITLE
docs(CHANGELOG.md): add entry for v0.0.1 and v0.0.2 pre-release 

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -2,6 +2,6 @@
 name = "cz_conventional_commits"
 tag_format = "v1.0.0"
 version_scheme = "semver"
-version = "0.0.1"
+version = "0.0.2"
 update_changelog_on_bump = true
 major_version_zero = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,19 @@
-## v0.0.1 (2025-04-08)
+## v0.0.2 (2025-04-07)
+
+### Fix
+
+- increase Astronomy Shop resource limits to avoid OOM errors (#39)
+- correct LLMConfigModelAgent class variables (#24)
+- update e2e environment variables and scripts (#21)
+- correct s3_endpoint_url references (#16)
+- correct typo (#12)
+
+## v0.0.1 (2025-03-20)
 
 This pre-release is the version (with fixes) used for in the ICML paper described [here](https://github.com/IBM/ITBench).
 
 ### Feat
 
-- add Dependabot for python and golang dependencies (#29)
-- add dependabot updates for Docker images (#25)
-- add pre-commit, commitizen, and detect-secrets tools (#11)
-
-### Fix
-
-- correct directory location of CISO scenarios Dockerfile (#44)
-- increase Astronomy Shop resource limits to avoid OOM errors (#39)
-- remove freeze files and dependabot groups (#35)
-- apply grouping to dependabot docker pull requests (#28)
-- correct LLMConfigModelAgent class variables (#24)
-- update e2e environment variables and scripts (#21)
-- correct s3_endpoint_url references (#16)
-- correct typo (#12)
+- add CODEOWNERS (#2)
+- add CISO incidents (#1)
+- add SRE incidents (#6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.0.1 (2025-04-08)
+## v0.0.1 (2025-04-08)
+
+This pre-release is the version (with fixes) used for in the ICML paper described [here](https://github.com/IBM/ITBench).
 
 ### Feat
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+## 0.0.1 (2025-04-08)
+
+### Feat
+
+- add Dependabot for python and golang dependencies (#29)
+- add dependabot updates for Docker images (#25)
+- add pre-commit, commitizen, and detect-secrets tools (#11)
+
+### Fix
+
+- correct directory location of CISO scenarios Dockerfile (#44)
+- increase Astronomy Shop resource limits to avoid OOM errors (#39)
+- remove freeze files and dependabot groups (#35)
+- apply grouping to dependabot docker pull requests (#28)
+- correct LLMConfigModelAgent class variables (#24)
+- update e2e environment variables and scripts (#21)
+- correct s3_endpoint_url references (#16)
+- correct typo (#12)


### PR DESCRIPTION
This PR adds a `CHANGELOG.md` file with an entry describing the v0.0.1 pre-release.