### PR TITLE
docs(CONTRIBUTING.md): update pre-commit install instructions 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ python -m pip install -r requirements-dev.txt
 
 ```shell
 pre-commit install
+pre-commit install --hook-type commit-msg --hook-type pre-push
 ```
 
 ## Committing Code


### PR DESCRIPTION
This PR updates the instructions for installing `pre-commit` hooks so that `commitizen` will run on a fresh installation.