### PR TITLE
feat: add docker build-push actions for SRE scenario tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
 
   - package-ecosystem: docker
     directories:
-      - sre/tools/**/
+      - sre/tools/kubernetes-topology-mapper/
+      - sre/tools/elasticsearch-dummy-app/
       - ciso/
     schedule:
       interval: weekly

--- a/.github/workflows/sre-build-push-images.yaml
+++ b/.github/workflows/sre-build-push-images.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - sre/tools/kubernetes-topology-mapper/*
+      - sre/tools/astronomy-shop-checkout-service/*
 
 jobs:
   docker:
@@ -21,11 +22,34 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and push
+      - name: Build and push Kubernetes Topology Mapper
         uses: docker/build-push-action@v6
         with:
           context: sre/tools/kubernetes-topology-mapper
+          platform:
+            - linux/amd64
+            - linux/arm64
           push: true
           tags:
             - it-bench/topology-monitor:0.0.1
             - it-bench/topology-monitor:latest
+      - name: Build and push Unsupported Astronomy Shop Checkout Service image (amd)
+        uses: docker/build-push-action@v6
+        with:
+          context: sre/tools/kubernetes-topology-mapper
+          platform:
+            - linux/amd64
+          push: true
+          tags:
+            - it-bench/unsupported-checkout-service-amd64:0.0.1
+            - it-bench/unsupported-checkout-service-amd64:latest
+      - name: Build and push Unsupported Astronomy Shop Checkout Service image (arm)
+        uses: docker/build-push-action@v6
+        with:
+          context: sre/tools/kubernetes-topology-mapper
+          platform:
+            - linux/arm64
+          push: true
+          tags:
+            - it-bench/unsupported-checkout-service-arm64:0.0.1
+            - it-bench/unsupported-checkout-service-arm64:latest

--- a/.github/workflows/sre-build-push-images.yaml
+++ b/.github/workflows/sre-build-push-images.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: Build and push SRE tool images
 
 on:
   push:

--- a/.github/workflows/sre-build-push-images.yaml
+++ b/.github/workflows/sre-build-push-images.yaml
@@ -1,0 +1,31 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - sre/tools/kubernetes-topology-mapper/*
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: sre/tools/kubernetes-topology-mapper
+          push: true
+          tags:
+            - it-bench/topology-monitor:0.0.1
+            - it-bench/topology-monitor:latest

--- a/.github/workflows/sre-build-push-images.yaml
+++ b/.github/workflows/sre-build-push-images.yaml
@@ -9,7 +9,7 @@ on:
       - sre/tools/astronomy-shop-checkout-service/*
 
 jobs:
-  docker:
+  topology-monitor:
     runs-on: ubuntu-latest
     steps:
       - name: Login to Quay.io
@@ -33,10 +33,23 @@ jobs:
           tags:
             - it-bench/topology-monitor:0.0.1
             - it-bench/topology-monitor:latest
+  unsupported-checkout-service:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push Unsupported Astronomy Shop Checkout Service image (amd)
         uses: docker/build-push-action@v6
         with:
-          context: sre/tools/kubernetes-topology-mapper
+          context: sre/tools/astronomy-shop-checkout-service
           platform:
             - linux/amd64
           push: true
@@ -46,7 +59,7 @@ jobs:
       - name: Build and push Unsupported Astronomy Shop Checkout Service image (arm)
         uses: docker/build-push-action@v6
         with:
-          context: sre/tools/kubernetes-topology-mapper
+          context: sre/tools/astronomy-shop-checkout-service
           platform:
             - linux/arm64
           push: true

--- a/sre/tools/astronomy-shop-checkout-service/Dockerfile
+++ b/sre/tools/astronomy-shop-checkout-service/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/open-telemetry/demo:1.12.0-checkoutservice
+
+ENTRYPOINT [ "./checkout" ]

--- a/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
+++ b/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
@@ -18,10 +18,10 @@ spec:
         fsGroup: 1000
       containers:
       - name: topology-monitor
-        image: quay.io/it-bench/topology-monitor:latest
+        image: quay.io/it-bench/topology-monitor:0.0.1
         imagePullPolicy: Always
         command: ["python"]
-        args: 
+        args:
         - "main.py"
         - "--data-dir=/app/topology_data"
         - "--interval=300"


### PR DESCRIPTION
This PR adds a GitHub action to build and push the topology mapper tools to the image repository.