### PR TITLE
bump: update sre tools docker image tags to v0.0.2

### DIFF
--- a/.github/workflows/sre-build-push-images.yaml
+++ b/.github/workflows/sre-build-push-images.yaml
@@ -26,6 +26,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build and push Kubernetes Topology Mapper
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: sre/tools/kubernetes-topology-mapper
           platforms: |
@@ -33,7 +35,7 @@ jobs:
             linux/arm64
           push: true
           tags: |
-            quay.io/it-bench/topology-monitor:0.0.1
+            quay.io/it-bench/topology-monitor:0.0.2
             quay.io/it-bench/topology-monitor:latest
   unsupported-checkout-service:
     runs-on: ubuntu-latest
@@ -52,21 +54,25 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build and push Unsupported Astronomy Shop Checkout Service image (amd)
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: sre/tools/astronomy-shop-checkout-service
           platforms: |
             linux/amd64
           push: true
           tags: |
-            quay.io/it-bench/unsupported-checkout-service-amd64:0.0.1
+            quay.io/it-bench/unsupported-checkout-service-amd64:0.0.2
             quay.io/it-bench/unsupported-checkout-service-amd64:latest
       - name: Build and push Unsupported Astronomy Shop Checkout Service image (arm)
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: sre/tools/astronomy-shop-checkout-service
           platforms: |
             linux/arm64
           push: true
           tags: |
-            quay.io/it-bench/unsupported-checkout-service-arm64:0.0.1
+            quay.io/it-bench/unsupported-checkout-service-arm64:0.0.2
             quay.io/it-bench/unsupported-checkout-service-arm64:latest

--- a/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
+++ b/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: topology-monitor
-        image: quay.io/it-bench/topology-monitor:0.0.1
+        image: quay.io/it-bench/topology-monitor:0.0.2
         imagePullPolicy: Always
         command: ["python"]
         args:


### PR DESCRIPTION
This PR updates the SRE tool docker tags to v0.0.2