### PR TITLE
bump: update observability and fault tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
   - package-ecosystem: "docker"
     directories:
       - "ciso/"
+    groups:
+      docker-production-dependencies:
+        dependency-type: "production"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: "docker"
+    directories:
       - "sre/tools/kubernetes-topology-mapper/"
       - "sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/"
     groups:
@@ -33,8 +41,8 @@ updates:
     directories:
       - "/"
       - "sre/"
-      - "sre/tools/**/"
       - "sre/remote_cluster/"
+      - "sre/tools/kubernetes-topology-mapper/"
     groups:
       pip-production-dependencies:
         dependency-type: "production"

--- a/sre/group_vars/fault_injection.yaml
+++ b/sre/group_vars/fault_injection.yaml
@@ -8,8 +8,8 @@ is_otel_astronomy_shop_dynamic_load: false
 
 # ChaosMesh configuration
 chaos_mesh_installation_name: "chaos-mesh"
-chaos_mesh_chart_version: "2.7.0"
-chaos_mesh_version_number: "2.7.0"
+chaos_mesh_namespace_project_name: "chaos-mesh"
+chaos_mesh_chart_version: 2.7.1
 
 # Default fault injection-removal values
 is_fault_injection: false
@@ -17,7 +17,6 @@ is_fault_removal: false
 
 # Chaos Mesh-based Faults
 is_install_chaos_mesh: false
-chaos_mesh_namespace_project_name: "chaos-mesh"
 is_network_delay_chaos: false
 is_network_partition_chaos: false
 is_pod_chaos: false

--- a/sre/group_vars/observability_tools.yaml
+++ b/sre/group_vars/observability_tools.yaml
@@ -2,19 +2,18 @@
 # Opensearch configuration
 opensearch_namespace_project_name: "opensearch"
 opensearch_installation_name: "opensearch"
-opensearch_chart_version: "2.31.0"
-opensearch_version_number: "2.19.0"
+opensearch_chart_version: 2.32.0
 
 # Prometheus - Grafana configuration
 prometheus_namespace_project_name: "prometheus"
 prometheus_installation_name: "prometheus"
-prometheus_chart_version: "27.8.0"
+prometheus_chart_version: 27.8.0
 prometheus_service_name: "prometheus-server"
 
 # Clickhouse
 clickhouse_namespace_project_name: "clickhouse"
 clickhouse_installation_name: "clickhouse"
-clickhouse_chart_version: "0.2.0"
+clickhouse_chart_version: 0.2.2
 
 # Nginx Ingress
 ingress_installation_name: ingress-nginx
@@ -24,17 +23,17 @@ ingress_chart_version: 4.12.1
 # Opencost
 opencost_namespace_project_name: "opencost"
 opencost_installation_name: "opencost"
-opencost_chart_version: "1.43.2"
+opencost_chart_version: 2.0.1
 
 # Kubernetes Metrics Server
 metrics_server_namespace_project_name: "metrics-server"
 metrics_server_installation_name: "metrics-server"
-metrics_server_chart_version: "3.12.2"
+metrics_server_chart_version: 3.12.2
 
 # OpenTelemetry Operator & Collector
 opentelemetry_operator_installation_name: opentelemetry-operator
 opentelemetry_operator_namespace_project_name: opentelemetry-operator
-opentelemetry_operator_chart_version: 0.84.2
+opentelemetry_operator_chart_version: 0.86.0
 
 opentelemetry_operator_collectors_namespace: opentelemetry-collectors
 opentelemetry_operator_collector_jaeger_name: jaeger

--- a/sre/group_vars/observability_tools.yaml
+++ b/sre/group_vars/observability_tools.yaml
@@ -33,7 +33,7 @@ metrics_server_chart_version: 3.12.2
 # OpenTelemetry Operator & Collector
 opentelemetry_operator_installation_name: opentelemetry-operator
 opentelemetry_operator_namespace_project_name: opentelemetry-operator
-opentelemetry_operator_chart_version: 0.86.0
+opentelemetry_operator_chart_version: 0.85.0
 
 opentelemetry_operator_collectors_namespace: opentelemetry-collectors
 opentelemetry_operator_collector_jaeger_name: jaeger

--- a/sre/group_vars/observability_tools.yaml
+++ b/sre/group_vars/observability_tools.yaml
@@ -7,7 +7,7 @@ opensearch_chart_version: 2.32.0
 # Prometheus - Grafana configuration
 prometheus_namespace_project_name: "prometheus"
 prometheus_installation_name: "prometheus"
-prometheus_chart_version: 27.8.0
+prometheus_chart_version: 27.11.0
 prometheus_service_name: "prometheus-server"
 
 # Clickhouse

--- a/sre/roles/fault_injection/tasks/install_chaos_mesh.yaml
+++ b/sre/roles/fault_injection/tasks/install_chaos_mesh.yaml
@@ -34,6 +34,8 @@
       chaosDaemon:
         runtime: containerd
         socketPath: /run/containerd/containerd.sock
+      dnsServer:
+        create: false
   tags:
     - fault_injection
     - chaos_mesh_installation

--- a/sre/roles/fault_injection/tasks/install_chaos_mesh.yaml
+++ b/sre/roles/fault_injection/tasks/install_chaos_mesh.yaml
@@ -30,13 +30,10 @@
     release_namespace: "{{ chaos_mesh_namespace_project_name }}"
     release_state: present
     create_namespace: true
-    set_values:
-      - value: chaosDaemon.runtime=containerd
-        value_type: raw
-      - value: chaosDaemon.socketPath=/run/containerd/containerd.sock
-        value_type: raw
-      - value: "version={{ chaos_mesh_version_number }}"
-        value_type: raw
+    values:
+      chaosDaemon:
+        runtime: containerd
+        socketPath: /run/containerd/containerd.sock
   tags:
     - fault_injection
     - chaos_mesh_installation
@@ -51,4 +48,3 @@
     - fault_injection
     - chaos_mesh_installation
   when: is_install_chaos_mesh | bool
-

--- a/sre/roles/observability_tools/tasks/install_opentelemetry.yaml
+++ b/sre/roles/observability_tools/tasks/install_opentelemetry.yaml
@@ -83,7 +83,7 @@
         name: "{{ opentelemetry_operator_collector_kubernetes_events_name }}"
         namespace: "{{ opentelemetry_operator_collectors_namespace }}"
       spec:
-        image: otel/opentelemetry-collector-contrib:0.120.0
+        image: otel/opentelemetry-collector-contrib:0.123.0
         serviceAccount: "{{ opentelemetry_operator_collector_kubernetes_events_name }}-collector"
         config:
           exporters:

--- a/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
+++ b/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       - name: topology-monitor
         image: quay.io/it-bench/topology-monitor:0.0.2
         imagePullPolicy: Always
-        command: ["python"]
+        command: ["python3.12"]
         args:
         - "main.py"
         - "--data-dir=/app/topology_data"


### PR DESCRIPTION
This PR updates the `observability` and `fault` tools to their latest versions. In addition, it also changes the `Dependabot` check frequency and updates the dependencies in the topology mapper.