### PR TITLE
chore: update pre-commit commitizen check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
     stages:
     - pre-push
   repo: https://github.com/commitizen-tools/commitizen
-  rev: v4.5.1
+  rev: v4.6.0


### PR DESCRIPTION
This PR updates the `pre-commit` `commitizen` tool to the latest after #74 .