### PR TITLE
chore: update base image of topology mapper to minimal ubi9 image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     directories:
       - "ciso/"
       - "sre/tools/kubernetes-topology-mapper/"
+      - "sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/"
     groups:
       docker-production-dependencies:
         dependency-type: "production"
@@ -39,7 +40,5 @@ updates:
         dependency-type: "production"
       pip-development-dependencies:
         dependency-type: "development"
-        exclude-patterns:
-          - elasticsearch
     schedule:
       interval: "daily"

--- a/.github/workflows/sre-build-push-tools.yaml
+++ b/.github/workflows/sre-build-push-tools.yaml
@@ -35,7 +35,7 @@ jobs:
             linux/arm64
           push: true
           tags: |
-            quay.io/it-bench/topology-monitor:0.0.2
+            quay.io/it-bench/topology-monitor:0.0.3
             quay.io/it-bench/topology-monitor:latest
   unsupported-checkout-service:
     runs-on: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
             linux/amd64
           push: true
           tags: |
-            quay.io/it-bench/unsupported-checkout-service-amd64:0.0.2
+            quay.io/it-bench/unsupported-checkout-service-amd64:0.0.3
             quay.io/it-bench/unsupported-checkout-service-amd64:latest
       - name: Build and push Unsupported Astronomy Shop Checkout Service image (arm)
         uses: docker/build-push-action@v6
@@ -74,5 +74,5 @@ jobs:
             linux/arm64
           push: true
           tags: |
-            quay.io/it-bench/unsupported-checkout-service-arm64:0.0.2
+            quay.io/it-bench/unsupported-checkout-service-arm64:0.0.3
             quay.io/it-bench/unsupported-checkout-service-arm64:latest

--- a/sre/roles/fault_injection/tasks/run_unsupported_image.yaml
+++ b/sre/roles/fault_injection/tasks/run_unsupported_image.yaml
@@ -69,7 +69,7 @@
     patch:
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: quay.io/it-bench/unsupported-checkout-service-{{ image_arch }}:0.0.2
+        value: quay.io/it-bench/unsupported-checkout-service-{{ image_arch }}:0.0.3
   tags:
     - incident_23
   when:

--- a/sre/tools/kubernetes-topology-mapper/Dockerfile
+++ b/sre/tools/kubernetes-topology-mapper/Dockerfile
@@ -1,11 +1,14 @@
-FROM registry.access.redhat.com/ubi9/python-312:9.5-1744198409
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1742914212
 
 ENV DATA_DIRECTORY /app/topology_data
 
 WORKDIR /app
 
+RUN microdnf update -y && \
+    microdnf install -y python3.12 python3.12-pip
+
 COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python3.12 -m pip install --no-cache-dir -r requirements.txt
 
 COPY __init__.py __init__.py
 COPY app.py app.py
@@ -24,4 +27,4 @@ RUN mkdir ${DATA_DIRECTORY} && \
 
 USER 1001
 
-CMD ["python", "main.py"]
+CMD ["python3.12", "main.py"]

--- a/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
+++ b/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: topology-monitor
-        image: quay.io/it-bench/topology-monitor:0.0.2
+        image: quay.io/it-bench/topology-monitor:0.0.3
         imagePullPolicy: Always
         command: ["python"]
         args:

--- a/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
+++ b/sre/tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: topology-monitor
-        image: quay.io/it-bench/topology-monitor:0.0.3
+        image: quay.io/it-bench/topology-monitor:0.0.2
         imagePullPolicy: Always
         command: ["python"]
         args:

--- a/sre/tools/kubernetes-topology-mapper/requirements.txt
+++ b/sre/tools/kubernetes-topology-mapper/requirements.txt
@@ -1,6 +1,6 @@
-kubernetes==29.0.0
-openshift-client==1.0.18
+kubernetes==32.0.1
+openshift-client==1.0.24
 openshift==0.13.2
-networkx==3.2.1
-Flask==3.0.0
-PyYAML==6.0.1
+networkx==3.4.2
+Flask==3.1.0
+PyYAML==6.0.2


### PR DESCRIPTION
This PR updates the `kubernetes-topology-mapper` tool to be built from the minimal ubi9 image. This allows the final build image to be smaller and only contain the minimal amount of needed software.