### PR TITLE
feat: add Prometheus alert name validation

### DIFF
--- a/.github/workflows/sre-validate-alerts.yaml
+++ b/.github/workflows/sre-validate-alerts.yaml
@@ -1,0 +1,25 @@
+name: Validate SRE Prometheus alert names
+
+on:
+  pull_request:
+    branches:
+      - main
+    # paths:
+    #   - sre/roles/observability_tools/templates/prometheus-alerting-rules.j2
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install Python dependencies
+        run: pip install -r sre/requirements.txt
+      - name: Install Ansible dependecies
+        run: ansible-galaxy install -r sre/requirements.yaml
+      - name: Run validation playbook
+        run: ansible-playbook -v sre/validate.yaml

--- a/.github/workflows/sre-validate-alerts.yaml
+++ b/.github/workflows/sre-validate-alerts.yaml
@@ -4,8 +4,8 @@ on:
   pull_request:
     branches:
       - main
-    # paths:
-    #   - sre/roles/observability_tools/templates/prometheus-alerting-rules.j2
+    paths:
+      - sre/roles/observability_tools/templates/prometheus-alerting-rules.j2
 
 jobs:
   validate:

--- a/sre/validate.yaml
+++ b/sre/validate.yaml
@@ -1,0 +1,44 @@
+---
+- name: Temporary Validator
+  hosts:
+    - localhost
+  vars:
+    alerting_rules_names:
+      - PendingPodsDetected
+      - FailedPodsDetected
+      - RequestLatency
+      - RequestErrorRate
+      - KafkaConnectionClosureRate
+      - CPUSpend
+      - MemorySpend
+      - CPUEfficiency
+      - MemoryEfficiency
+    enable_finops_rules: true
+  tasks:
+    - name: Template the alerting rules file to get full rules list
+      ansible.builtin.template:
+        src: roles/observability_tools/templates/prometheus-alerting-rules.j2
+        dest: /tmp/prometheus-alerting-rules-validation.yaml
+        variable_start_string: "<<"
+        variable_end_string: ">>"
+        mode: '0644'
+
+    - name: Load alert rules from file as yaml
+      ansible.builtin.set_fact:
+        rules: "{{ lookup('ansible.builtin.file', '/tmp/prometheus-alerting-rules-validation.yaml') | from_yaml }}"
+
+    - name: Parse alerting rules names from list
+      ansible.builtin.set_fact:
+        names: "{{ rules | community.general.json_query('groups[*].rules[*].alert') | flatten | unique }}"
+
+    - name: Check for differences between file and validated alerts
+      ansible.builtin.set_fact:
+        result: "{{ names | difference(alerting_rules_names) }}"
+
+    - name: Validate result
+      ansible.builtin.assert:
+        that: "result | length == 0"
+        fail_msg: "Alerting rules template file contains invalid alert names: {{ result }}."
+        success_msg: "Ok"
+      tags:
+        - always


### PR DESCRIPTION
This PR adds a temporary validation playbook script for ensuring that the alert names are correct. Consistency for the alert names are needed in order for the group truth of each incident. This implementation is only temporary until after the completion of #61 , where it will be better re-implemented.