### PR TITLE
chore: add alert name validation for incident ground truth documentation

### DIFF
--- a/sre/group_vars/documentation.yaml
+++ b/sre/group_vars/documentation.yaml
@@ -1,4 +1,5 @@
 ---
 # This empty list gets appended to by every incident tasks/main.yaml file
 documentation_json_file: "/tmp/sre-bench-docs.json"
-all_incidents: []
+all_incidents: [] # global list to which all or selected incidents get appended to at runtime
+selected_incidents: [1, 3, 23, 26, 27, 37, 102] # when left blank all incidents are selected

--- a/sre/roles/documentation/defaults/main/incidents_schema.yaml
+++ b/sre/roles/documentation/defaults/main/incidents_schema.yaml
@@ -87,6 +87,17 @@ valid_documentation_schema:
           properties:
             "id":
               type: string
+              enum: [ # Prometheus alert names as defined in roles/observability_tools/templates/prometheus-alerting-rules.j2
+                      "FailedPodsDetected",
+                      "PendingPodsDetected",
+                      "RequestLatency",
+                      "RequestErrorRate",
+                      "KafkaConnectionClosureRate",
+                      "CPUSpend",
+                      "MemorySpend",
+                      "CPUEfficiency",
+                      "MemoryEfficiency"
+                    ]
             "group_id":
               type: string
             "metadata":

--- a/sre/roles/documentation/tasks/collect_documentation.yaml
+++ b/sre/roles/documentation/tasks/collect_documentation.yaml
@@ -1,15 +1,15 @@
 ---
-- name: Find all incident roles
+- name: Find all/select incident roles
   find:
     paths: "roles" 
-    patterns: "incident_*"
+    patterns: "{{ selected_incidents | map('regex_replace', '^', 'incident_') | list | default('incident_*') }}"
     file_type: "directory"
     recurse: False
   register: incident_roles
   tags:
     - documentation
 
-- name: Include all of the incident roles
+- name: Include all of or selected incident roles
   ansible.builtin.include_role:
     name: '{{ item["path"] }}'
   loop: "{{ incident_roles['files'] }}"


### PR DESCRIPTION
adds validation of `Alert Names / IDs` in `make documentation`. Alternate to #84 in a way. Wondering if #84 at this point could simply call `make documentation` as there are already a number of other checks in place there-in.