### PR TITLE
chore: remove Ingress for OpenCost UI

### DIFF
--- a/sre/roles/observability_tools/tasks/install_opencost.yaml
+++ b/sre/roles/observability_tools/tasks/install_opencost.yaml
@@ -38,15 +38,3 @@
             url: "http://{{ prometheus_service_name }}.{{ prometheus_namespace_project_name }}.svc.cluster.local:80"
           internal:
             enabled: false
-        ui:
-          ingress:
-            annotations:
-              # nginx.ingress.kubernetes.io/rewrite-target: /$2
-              nginx.ingress.kubernetes.io/enable-cors: "true"
-            enabled: true
-            hosts:
-              - host: null
-                paths:
-                  - /
-                  # - /{{ opencost_namespace_project_name }}(/|$)(.*)
-            ingressClassName: nginx


### PR DESCRIPTION
This PR removes the Ingress for the OpenCost UI. The UI only offers a visualization of the data collected and is not a query-able component.