### PR TITLE
fix: add Content-Security-Policy headers to Ingress traffic

### DIFF
--- a/sre/roles/observability_tools/tasks/install_ingress.yaml
+++ b/sre/roles/observability_tools/tasks/install_ingress.yaml
@@ -2,7 +2,10 @@
 - name: Set Context Security Policies
   ansible.builtin.set_fact:
     security_policies:
-      - default-src 'self'
+      # - default-src 'self'
+      # - script-src 'self'
+      # - "style-src 'self'"
+      - "img-src 'self' data:"
       - form-action 'none'
       - frame-ancestors 'none'
 
@@ -21,4 +24,5 @@
       controller:
         addHeaders:
           "Content-Security-Policy": "{{ security_policies | join('; ') }}"
+          "Content-Security-Policy-Report-Only": default-src 'self'
           "X-Content-Type-Options": nosniff

--- a/sre/roles/observability_tools/tasks/install_ingress.yaml
+++ b/sre/roles/observability_tools/tasks/install_ingress.yaml
@@ -1,32 +1,13 @@
 ---
-- name: Create namespace(s) for Nginx-Ingress -- to-be removed in OpenShift deployment PR
-  kubernetes.core.k8s:
-    kubeconfig: "{{ kubeconfig }}"
-    state: present
-    resource_definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: "{{ ingress_namespace_project_name }}"
-
-- name: Create ConfigMap with security headers
-  kubernetes.core.k8s:
-    kubeconfig: "{{ kubeconfig }}"
-    state: present
-    definition:
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: security-headers
-        namespace: "{{ ingress_namespace_project_name }}"
-      data:
-        X-Content-Type-Options: "nosniff"
-        X-Frame-Options: "DENY"
-        X-XSS-Protection: "0"
-        Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
-        Content-Security-Policy: "img-src 'self' data:; connect-src 'self'; font-src 'self'; object-src 'none'; form-action 'none'; frame-ancestors 'none'"
-        Cross-Origin-Resource-Policy: "same-origin"
-        Referrer-Policy: "strict-origin-when-cross-origin"
+- name: Set Context Security Policies
+  ansible.builtin.set_fact:
+    security_policies:
+      - "img-src 'self' data:"
+      - connect-src 'self'
+      - font-src 'self'
+      - object-src 'none'
+      - form-action 'none'
+      - frame-ancestors 'none'
 
 - name: Set up Nginx Ingress
   kubernetes.core.helm:
@@ -34,13 +15,21 @@
     kubeconfig_path: "{{ kubeconfig }}"
     chart_ref: ingress-nginx/ingress-nginx
     chart_version: "{{ ingress_chart_version }}"
+    create_namespace: true
     release_namespace: "{{ ingress_namespace_project_name }}"
     release_state: present
     wait: true
     timeout: 20m0s
     values:
       controller:
+        addHeaders:
+          "X-Content-Type-Options": nosniff
+          "X-Frame-Options": DENY
+          "X-XSS-Protection": "0"
+          "Strict-Transport-Security": max-age=31536000; includeSubDomains; preload
+          "Content-Security-Policy": "{{ security_policies | join('; ') }}"
+          "Cross-Origin-Resource-Policy": same-origin
+          "Referrer-Policy": strict-origin-when-cross-origin
         config:
-          add-headers: "{{ ingress_namespace_project_name }}/security-headers"
           server-tokens: "false"
   ignore_errors: yes

--- a/sre/roles/observability_tools/tasks/install_ingress.yaml
+++ b/sre/roles/observability_tools/tasks/install_ingress.yaml
@@ -1,4 +1,11 @@
 ---
+- name: Set Context Security Policies
+  ansible.builtin.set_fact:
+    security_policies:
+      - default-src 'self'
+      - form-action 'none'
+      - frame-ancestors 'none'
+
 - name: Set up Nginx Ingress
   kubernetes.core.helm:
     name: "{{ ingress_installation_name }}"
@@ -10,4 +17,8 @@
     create_namespace: true
     wait: true
     timeout: 20m0s
-  ignore_errors: yes
+    values:
+      controller:
+        addHeaders:
+          "Content-Security-Policy": "{{ security_policies | join('; ') }}"
+          "X-Content-Type-Options": nosniff

--- a/sre/roles/observability_tools/tasks/install_ingress.yaml
+++ b/sre/roles/observability_tools/tasks/install_ingress.yaml
@@ -1,10 +1,32 @@
 ---
-- name: Set Context Security Policies
-  ansible.builtin.set_fact:
-    security_policies:
-      - "img-src 'self' data:"
-      - form-action 'none'
-      - frame-ancestors 'none'
+- name: Create namespace(s) for observability components
+  kubernetes.core.k8s:
+    kubeconfig: "{{ kubeconfig }}"
+    state: present
+    resource_definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ ingress_namespace_project_name }}"
+
+- name: Create ConfigMap with security headers
+  kubernetes.core.k8s:
+    kubeconfig: "{{ kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: security-headers
+        namespace: "{{ ingress_namespace_project_name }}"
+      data:
+        X-Content-Type-Options: "nosniff"
+        X-Frame-Options: "DENY"
+        X-XSS-Protection: "0"
+        Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
+        Content-Security-Policy: "img-src 'self' data:; connect-src 'self'; font-src 'self'; object-src 'none'; form-action 'none'; frame-ancestors 'none'"
+        Cross-Origin-Resource-Policy: "same-origin"
+        Referrer-Policy: "strict-origin-when-cross-origin"
 
 - name: Set up Nginx Ingress
   kubernetes.core.helm:
@@ -14,11 +36,11 @@
     chart_version: "{{ ingress_chart_version }}"
     release_namespace: "{{ ingress_namespace_project_name }}"
     release_state: present
-    create_namespace: true
     wait: true
     timeout: 20m0s
     values:
       controller:
-        addHeaders:
-          "Content-Security-Policy": "{{ security_policies | join('; ') }}"
-          "X-Content-Type-Options": nosniff
+        config:
+          add-headers: "{{ ingress_namespace_project_name }}/security-headers"
+          server-tokens: "false"
+  ignore_errors: yes

--- a/sre/roles/observability_tools/tasks/install_ingress.yaml
+++ b/sre/roles/observability_tools/tasks/install_ingress.yaml
@@ -2,9 +2,6 @@
 - name: Set Context Security Policies
   ansible.builtin.set_fact:
     security_policies:
-      # - default-src 'self'
-      # - script-src 'self'
-      # - "style-src 'self'"
       - "img-src 'self' data:"
       - form-action 'none'
       - frame-ancestors 'none'
@@ -24,5 +21,4 @@
       controller:
         addHeaders:
           "Content-Security-Policy": "{{ security_policies | join('; ') }}"
-          "Content-Security-Policy-Report-Only": default-src 'self'
           "X-Content-Type-Options": nosniff

--- a/sre/roles/observability_tools/tasks/install_ingress.yaml
+++ b/sre/roles/observability_tools/tasks/install_ingress.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Create namespace(s) for observability components
+- name: Create namespace(s) for Nginx-Ingress -- to-be removed in OpenShift deployment PR
   kubernetes.core.k8s:
     kubeconfig: "{{ kubeconfig }}"
     state: present

--- a/sre/roles/observability_tools/tasks/install_opencost.yaml
+++ b/sre/roles/observability_tools/tasks/install_opencost.yaml
@@ -40,9 +40,9 @@
             enabled: false
         ui:
           ingress:
-            annotations:
+            # annotations:
               # nginx.ingress.kubernetes.io/rewrite-target: /$2
-              nginx.ingress.kubernetes.io/enable-cors: "true"
+              # nginx.ingress.kubernetes.io/enable-cors: "true"
             enabled: true
             hosts:
               - host: null

--- a/sre/roles/observability_tools/tasks/install_opencost.yaml
+++ b/sre/roles/observability_tools/tasks/install_opencost.yaml
@@ -40,9 +40,6 @@
             enabled: false
         ui:
           ingress:
-            # annotations:
-              # nginx.ingress.kubernetes.io/rewrite-target: /$2
-              # nginx.ingress.kubernetes.io/enable-cors: "true"
             enabled: true
             hosts:
               - host: null

--- a/sre/roles/observability_tools/tasks/install_prometheus.yaml
+++ b/sre/roles/observability_tools/tasks/install_prometheus.yaml
@@ -41,11 +41,15 @@
     release_state: present
     create_namespace: true
     values:
+      alertmanager:
+        extraArgs:
+          "web.route-prefix": /alertmanager
       extraScrapeConfigs: "{{ lookup('ansible.builtin.template', 'templates/prometheus-scrape-configs.j2') | from_yaml | to_yaml }}"
       server:
         extraFlags:
           - web.enable-lifecycle
           - web.enable-otlp-receiver
+        prefixURL: /prometheus
       serverFiles:
         alerting_rules.yml: "{{ lookup('ansible.builtin.template', '/tmp/prometheus-required-alerting-rules.j2') | from_yaml }}"
         recording_rules.yml: "{{ lookup('ansible.builtin.template', 'templates/prometheus-recording-rules.j2') | from_yaml }}"
@@ -62,8 +66,6 @@
       metadata:
         name: prometheus
         namespace: "{{ prometheus_namespace_project_name }}"
-        annotations:
-          nginx.ingress.kubernetes.io/rewrite-target: /$2
       spec:
         ingressClassName: nginx
         rules:


### PR DESCRIPTION
This PR adds `Content-Security-Policy` and other headers to the traffic handled by Ingress.