### PR TITLE
fix: update runner github group vars

### DIFF
--- a/sre/group_vars/runner/github.yaml.example
+++ b/sre/group_vars/runner/github.yaml.example
@@ -1,11 +1,13 @@
 ---
 github:
   it_bench:
+    branch: main
     # ssh:
     #   private_key_passphrase: ""
     #   private_key_path: ""
     url: https://github.com/itbench-hub/ITBench-Scenarios.git
   llm_agent:
+    branch: main
     # ssh:
     #   private_key_passphrase: ""
     #   private_key_path: ""


### PR DESCRIPTION
This PR updates the example file used to generate the `github` group vars after #208 .