### PR TITLE
docs: update cluster group variable path in documentation

### DIFF
--- a/sre/dev/remote_cluster/README.md
+++ b/sre/dev/remote_cluster/README.md
@@ -113,7 +113,7 @@ kubectl get pods --all-namespaces
 Update the `kubeconfig` path in your global configuration:
 
 ```bash
-vim ../group_vars/environment/cluster.yaml
+vim ../../group_vars/environment/cluster.yaml
 ```
 
 Set the absolute path where the kubeconfig should be downloaded:


### PR DESCRIPTION
I found a small typo in the README while setting up the remote cluster.

Step 4. Update Global Configuration
Old: vim ../group_vars/environment/cluster.yaml

New: vim ../../group_vars/environment/cluster.yaml