### PR TITLE
fix(awx): update manage_awx.yaml to use experiments.incidents

### DIFF
--- a/sre/playbooks/manage_awx.yaml
+++ b/sre/playbooks/manage_awx.yaml
@@ -33,7 +33,7 @@
           kubeconfig: "{{ stack.awx.kubeconfig }}"
         awx_credentials: "{{ credentials }}"
         awx_experiments:
-          scenarios: "{{ experiments.scenarios }}"
+          scenarios: "{{ experiments.incidents }}"
           storage: "{{ storage }}"
           trials: "{{ experiments.trials }}"
         awx_github: "{{ github }}"


### PR DESCRIPTION
The experiments dictionary uses 'incidents' instead of 'scenarios'. Updating this prevents the runtime error when validating AWX arguments in the main entry point

```
ASK [awx : Validating arguments against arg spec 'main' - Main entry point for awx role] ****************************************************************************************************
[ERROR]: Task failed: object of type 'dict' has no attribute 'scenarios'

Task failed.
Origin: <unknown>

{'action': 'ansible.builtin.validate_argument_spec', 'args': {'argument_spec': {'awx_agent': {'required': False, [...]

<<< caused by >>

object of type 'dict' has no attribute 'scenarios'
Origin: /Users/amymelamblasserial/ITBench-Scenarios/sre/playbooks/manage_awx.yaml:36:22

34         awx_credentials: "{{ credentials }}"
35         awx_experiments:
36           scenarios: "{{ experiments.scenarios }}"
                        ^ column 22

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: object of type 'dict' has no attribute 'scenarios'"}
```