### PR TITLE
fix: revert changes made to AWX playbook

### DIFF
--- a/sre/playbooks/manage_awx.yaml
+++ b/sre/playbooks/manage_awx.yaml
@@ -33,7 +33,7 @@
           kubeconfig: "{{ stack.awx.kubeconfig }}"
         awx_credentials: "{{ credentials }}"
         awx_experiments:
-          scenarios: "{{ experiments.incidents }}"
+          scenarios: "{{ experiments.scenarios }}"
           storage: "{{ storage }}"
           trials: "{{ experiments.trials }}"
         awx_github: "{{ github }}"


### PR DESCRIPTION
This PR reverts the changes made in #323 for two reasons:

1. These changes do break main as they do not include the necessary changes to [`group_vars/runner/experiments.yaml.example`](https://github.com/itbench-hub/ITBench-Scenarios/blob/13b6de1a51cb081492e8b9e91470df1412bd88c5/sre/group_vars/runner/experiments.yaml.example#L3) and thus cause the playbook to fail with the default variable generation.
2. The terminology of `scenarios` is already used. This term is preferred and `incidents` will be renamed into `scenarios` in a future PR.