### PR TITLE
docs: correct links to incidents documentation

### DIFF
--- a/sre/DEVELOPER_GUIDE.md
+++ b/sre/DEVELOPER_GUIDE.md
@@ -55,7 +55,7 @@ INCIDENT_NUMBER=1 make inject_incident_fault
 
 **Open-sourced incident scenarios:** 1, 3, 23, 26, 27, 102
 
-**Additional details:** [Incident scenarios and fault mechanisms](./docs/incident_scenarios.md)
+**Additional details:** [Incident scenarios and fault mechanisms](./docs/incidents.md)
 
 ### Step 4. Set Up Port Forwarding
 Enable access to the Prometheus and Jaeger dashboards:

--- a/sre/README.md
+++ b/sre/README.md
@@ -1,6 +1,6 @@
 # ITBench for Site Reliability Engineering (SRE) and Financial Operations (FinOps)
 
-**[Paper](https://github.com/IBM/ITBench/blob/main/it_bench_arxiv.pdf) | [Incident Scenarios](./docs/incident_scenarios.md) | [Tools](./docs/tools.md)**
+**[Paper](https://github.com/IBM/ITBench/blob/main/it_bench_arxiv.pdf) | [Incident Scenarios](./docs/incidents.md) | [Tools](./docs/tools.md)**
 
 ## Overview
 ITBench uses open source technologies to create completely repeatable and reproducible scenarios on a Kubernetes platform. A SRE scenario involves deploying a set of observability tools, a sample application, and triggering an incident (referred to as task) in the environment.


### PR DESCRIPTION
This PR fixes the broken "Incident Scenarios" link in the documentation:

- Corrected the link in `sre/README.md`.
- Corrected the link in `sre/DEVELOPER_GUIDE.md`.
- Verified that clicking the link now navigates to the correct page instead of returning a 404.