### PR TITLE
chore: lint remote cluster role files

### DIFF
--- a/sre/dev/remote_cluster/roles/kops/tasks/main.yaml
+++ b/sre/dev/remote_cluster/roles/kops/tasks/main.yaml
@@ -65,7 +65,7 @@
     cmd: kops get clusters --output json --state {{ kops_state_store }}
   register: kops_stack_clusters_output
   changed_when: false
-  ignore_errors: true
+  failed_when: false
   tags:
     - create_stack
     - delete_stack


### PR DESCRIPTION
This PR correct a lint error about using `ignore_errors`. Though, for some reason, the linter is not picking it up.