### PR TITLE
fix: raise Clickhouse request limit to 50MB

### DIFF
--- a/sre/roles/tools/files/clickhouse/installation.yaml
+++ b/sre/roles/tools/files/clickhouse/installation.yaml
@@ -16,19 +16,26 @@ spec:
     - name: clickhouse-data
     - name: clickhouse-pod
     - name: clickhouse-service
+
   configuration:
+
+    profiles:
+      max_result_profile:
+        max_result_bytes: 52428800   
+
     users:
       default/networks/ip: 0.0.0.0/0
       default/access_management: 1
       default/named_collection_control: 1
       default/show_named_collections: 1
       default/show_named_collections_secrets: 1
-      default/max_result_bytes: 52428800
+      default/profile: max_result_profile   
       default/password:
         valueFrom:
           secretKeyRef:
             name: user-default-credentials
             key: password
+
     clusters:
       - name: main
         layout:


### PR DESCRIPTION
- Updates the ClickHouse installation configuration to set `max_result_bytes` to 50 MB (52,428,800 bytes).
- Added the setting under the users section in `installation.yaml`