### PR TITLE
fix: correct entrypoint of opentelemetry collector image

### DIFF
--- a/sre/tools/opentelemetry-collector/Dockerfile
+++ b/sre/tools/opentelemetry-collector/Dockerfile
@@ -17,8 +17,10 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
 
+WORKDIR /
+
 COPY --from=builder /workspace/out/it-bench-otelcollector it-bench-otelcollector
 
-ENTRYPOINT ["./it-bench-otelcollector"]
+ENTRYPOINT ["/it-bench-otelcollector"]
 
 EXPOSE 4317 4318


### PR DESCRIPTION
This PR is a followup to #337 that fixes the entrypoint field of the image.