### PR TITLE
docs: add hardware specification documentation

### DIFF
--- a/sre/dev/local_cluster/README.md
+++ b/sre/dev/local_cluster/README.md
@@ -4,6 +4,8 @@ __Note: The following setup guide has been verified and tested on MacOS using th
 
 _Note: The following setup guide presumes that the required software listed [here](./README.md#required-software) has been installed. If it has not, please go back and do so before following this document._
 
+_Note: Please review the [hardware requirements](../../docs/hardware_specification.md) to ensure that the machine matches or exceeds the specifications._
+
 ## Recommended Software
 
 1. [Podman](https://podman.io/)
@@ -24,9 +26,9 @@ brew install go
 podman machine init
 ```
 
-2. Set the machine's resources. The tested configuration uses 12 CPU cores and 16 GB of RAM.
+2. Set the machine's resources.
 ```shell
-podman machine set --cpus 12 -m 16384
+podman machine set --cpus 8 -m 16384
 ```
 
 3. Start the Machine

--- a/sre/dev/local_cluster/README_RHEL.md
+++ b/sre/dev/local_cluster/README_RHEL.md
@@ -6,6 +6,8 @@ __Note: The following setup guide has been verified and tested on Red Hat Enterp
 
 _Note: The following setup guide presumes that the required software listed [here](./README.md#required-software) has been installed. If it has not, please go back and do so before following this document._
 
+_Note: Please review the [hardware requirements](../../docs/hardware_specification.md) to ensure that the machine matches or exceeds the specifications._
+
 ## Recommended Software
 
 1. [make] -- Ensure you have `make` installed or install it via `sudo dnf install make`

--- a/sre/docs/hardware_specification.md
+++ b/sre/docs/hardware_specification.md
@@ -1,0 +1,27 @@
+# ITBench: Hardware Specification
+
+ITBench executes its scenarios in a live environment ([Kubernetes](https://kubernetes.io/docs/concepts/overview/)). As such, one needs significant resources in order to run the benchmarks.
+
+## Local Development (Kind, Minikube, etc.)
+
+We recommend the following hardware requirements for good performance on a virtual or physical machine. Using a machine that has the below the recommended amount may result in sub-optimal performance or failures within ITBench.
+
+| CPU | Memory | Storage |
+| --- | --- | --- |
+| 8 | 16 GB | 50 GB |
+
+### Development on AWX
+
+When using AWX locally, one needs significate resources to ensure good performance. This is because a single cluster is responsible for running both AWX and the benchmark at the same time.
+
+Generally, it is not recommended to run AWX locally outside of testing purposes.
+
+| CPU | Memory | Storage |
+| --- | --- | --- |
+| 24 | 32 GB | 100 GB |
+
+## Remote Development (AWS, Azure, GCP, etc.)
+
+We recommend that the machines used for the cluster's worker nodes adhear to the same requirements as described in the [previous section](#local-development-kind-minikube-etc). For example, on AWS, the [`m5.2xlarge`](https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_hardware) is recommended for worker nodes.
+
+There is no hardware requirement for the local machine when using cloud resources to create a Kubernetes cluster.


### PR DESCRIPTION
This PR adds documentation about the hardware specifics needed to run ITBench.