### PR TITLE
docs: add table to applications documentation

### DIFF
--- a/sre/docs/applications.md
+++ b/sre/docs/applications.md
@@ -1,6 +1,10 @@
 # ITBench: Applications
 
-## [OpenTelemetry's Astronomy Shop](https://github.com/open-telemetry/opentelemetry-demo)
+| Application | Repository |
+| --- | --- |
+| [OpenTelemetry Demo](#opentelemetry-demo-astronomy-shop) | https://github.com/open-telemetry/opentelemetry-demo |
+
+## OpenTelemetry Demo (Astronomy Shop)
 
 OpenTelemetry's Astronomy Shop is a microservice-based distributed system intended to illustrate the implementation of OpenTelemetry in a near real-world environment.
 An architectural diagram for the same can be found [here](https://opentelemetry.io/docs/demo/architecture/).


### PR DESCRIPTION
This PR formats the applications docs with a table for easier referencing instead of the titles.