### PR TITLE
feat: enable BYOM or custom models hosted on watsonx.ai

### DIFF
--- a/sre/group_vars/runner/agent.yaml.example
+++ b/sre/group_vars/runner/agent.yaml.example
@@ -34,6 +34,7 @@ agent_configuration:
       max_tokens: 0
     watsonx_config:
       wx_project_id: ""
+      wx_deployment_space_id: ""
     agent_analytics_sdk:
       git_token: ""
       git_username: ""

--- a/sre/roles/awx/tasks/configure_jobs.yaml
+++ b/sre/roles/awx/tasks/configure_jobs.yaml
@@ -333,6 +333,7 @@
       thinking_budget_tools: "{{ awx_agent.configuration['tools_config']['thinking_budget'] }}"
       max_tokens_tools: "{{ awx_agent.configuration['tools_config']['max_tokens'] }}"
       wx_project_id: "{{ awx_agent.configuration['watsonx_config']['wx_project_id'] }}"
+      wx_deployment_space_id: "{{ awx_agent.configuration['watsonx_config']['wx_deployment_space_id'] }}"
       god_mode: "{{ awx_agent.configuration['agents_config']['god_mode'] }}"
       agent_analytics_sdk_username: "{{ awx_agent.configuration['agent_analytics_sdk']['git_username'] }}"
       agent_analytics_sdk_token: "{{ awx_agent.configuration['agent_analytics_sdk']['git_token'] }}"


### PR DESCRIPTION
This PR propagates the `deployment / space id` associated with a bring your own model (BYOM) or a custom foundation model hosted on watsonx to the AWX environment.

LiteLLM warrants the need of `WATSONX_DEPLOYMENT_SPACE_ID` to be present as an environment variable to facilitate the use of such BYOM and custom models on watsonx.ai: https://docs.litellm.ai/docs/providers/watsonx