### PR TITLE
fix: pin dependency version for AWX execution environment (EE) image builds

### DIFF
--- a/sre/tools/awx-ee/execution-environment.yaml
+++ b/sre/tools/awx-ee/execution-environment.yaml
@@ -16,22 +16,37 @@ dependencies:
     ---
     collections:
       - name: awx.awx
+        version: "24.6.1"
       - name: azure.azcollection
-        version: ">=2.1.0"
+        version: "3.9.0"
       - name: amazon.aws
+        version: "10.1.2"
       - name: theforeman.foreman
+        version: "5.7.0"
       - name: google.cloud
+        version: "1.9.0"
       - name: openstack.cloud
+        version: "2.5.0"
       - name: community.vmware
+        version: "6.1.0"
       - name: ovirt.ovirt
+        version: "3.2.1"
       - name: kubernetes.core
+        version: "6.2.0"
       - name: ansible.posix
+        version: "2.1.0"
       - name: ansible.windows
+        version: "3.2.0"
       - name: redhatinsights.insights
+        version: "1.3.0"
       - name: kubevirt.core
+        version: "2.2.3"
       - name: ansible.utils
+        version: "6.0.0"
       - name: community.general
+        version: "12.0.0"
       - name: community.aws
+        version: "10.0.0"
   system: |
     git-core [platform:rpm]
     lsof [platform:rpm]
@@ -39,6 +54,7 @@ dependencies:
     which [platform:rpm]
     python3.12-devel [platform:rpm]
     libcurl-devel [platform:rpm compile]
+    libuuid-devel [platform:rpm compile]
     krb5-devel [platform:rpm compile]
     krb5-workstation [platform:rpm]
     subversion [platform:rpm]
@@ -59,19 +75,19 @@ dependencies:
     tk-devel [platform:rpm]
     make [platform:rpm]
   python: |
-    git+https://github.com/ansible/ansible-sign
-    ncclient
-    paramiko
-    pykerberos
-    pyOpenSSL
-    pypsrp[kerberos,credssp]
-    pywinrm[kerberos,credssp]
-    toml
-    pexpect>=4.5
-    python-daemon
-    pyyaml
-    six
-    receptorctl
+    ansible-sign @ git+https://github.com/ansible/ansible-sign@59d5c75ef202ed1c57e124a378e59d1d4045219b
+    ncclient==0.7.0
+    paramiko==4.0.0
+    pykerberos==1.2.4
+    pyOpenSSL==24.2.1
+    pypsrp==0.8.1
+    pywinrm==0.5.0
+    toml==0.10.2
+    pexpect==4.9.0
+    python-daemon==3.1.2
+    PyYAML==6.0.3
+    six==1.16.0
+    receptorctl==1.6.1
 additional_build_steps:
   append_base:
     - RUN $PYCMD -m pip install -U pip


### PR DESCRIPTION
## Summary

This PR addresses the ARM64 build failure for our AWX Execution Environment and implements strict version pinning for better build reliability.

## Changes

- **Implements strict version pinning** - Now enforces specific versions for all Ansible collections and Python packages installed via pip

## Root Cause

The build failure was caused by a dependency chain issue:
1. Without version constraints, the build was pulling the latest Azure Ansible collection
2. This collection recently added a dependency on `azure-iot-hub` 
3. `azure-iot-hub` depends on `uamqp`, which is deprecated and incompatible with recent cmake versions. This incompatibility caused the ARM64 build to fail whereas on AMD64 it was able to use a pre-built wheel