### PR TITLE
fix: increase ClickHouse max_result_bytes to 50MB

### DIFF
--- a/sre/roles/tools/templates/clickhouse/installations/main.j2
+++ b/sre/roles/tools/templates/clickhouse/installations/main.j2
@@ -118,12 +118,16 @@ spec:
     - name: clickhouse-pod
     - name: clickhouse-service
   configuration:
+    profiles:
+      max-result-profile:
+        max_result_bytes: 52428800
     users:
       default/networks/ip: 0.0.0.0/0
       default/access_management: 1
       default/named_collection_control: 1
       default/show_named_collections: 1
       default/show_named_collections_secrets: 1
+      default/profile: max-result-profile
       default/password:
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Hi @Red-GV , 
Discarding this PR #343  as the ClickHouse file structure has changed.
The same change (increasing max_result_bytes to 50 MB) has been applied in the file `main.j2` in this PR: `fix-clickhouse-max-result-bytes`.
Issue link: [Clickhouse limited to 10MB requests #156](https://github.com/itbench-hub/ITBench-Scenarios/issues/156)
Could you please review?
Thanks!