### PR TITLE
fix: disable firing alerts and fix otel-demo telemetry metrics

### DIFF
--- a/sre/roles/applications/tasks/install_otel_demo.yaml
+++ b/sre/roles/applications/tasks/install_otel_demo.yaml
@@ -23,7 +23,6 @@
           openshift.io/sa.scc.uid-range: 1/2000
           openshift.io/sa.scc.supplemental-groups: 1/1000
         labels:
-          istio.io/dataplane-mode: ambient
           it-bench/monitoring: "true"
     state: present
 
@@ -322,7 +321,7 @@
             otlphttp/prometheus:
               endpoint: http://{{ helm_releases.prometheus.name }}-kube-prometheus-prometheus.{{ helm_releases.prometheus.namespace }}.svc.cluster.local:9090
             prometheus:
-              endpoint: 0.0.0.0:8889
+              endpoint: 0.0.0.0:8888
           service:
             pipelines:
               logs:
@@ -339,19 +338,40 @@
                   - debug
                   - otlp
                   - spanmetrics
+            telemetry:
+              metrics:
+                level: detailed
+                readers:
+                  - pull:
+                      # interval: 10000
+                      # timeout: 5000
+                      exporter:
+                        prometheus:
+                          host: 0.0.0.0
+                          port: 8889
         serviceMonitor:
           enabled: true
           metricsEndpoints:
-            - port: demo-metrics
             - port: metrics
+            - port: telemetry
         podAnnotations:
           openshift.io/required-scc: restricted-v2
         ports:
-          demo-metrics:
+          jaeger-compact:
+            enabled: false
+          jaeger-thrift:
+            enabled: false
+          jaeger-grpc:
+            enabled: false
+          metrics:
+            enabled: true
+          telemetry:
             enabled: true
             containerPort: 8889
             servicePort: 8889
             protocol: TCP
+          zipkin:
+            enabled: false
         resources:
           requests:
             cpu: 75m

--- a/sre/roles/tools/templates/helm_values/prometheus.j2
+++ b/sre/roles/tools/templates/helm_values/prometheus.j2
@@ -26,7 +26,11 @@ prometheus:
 defaultRules:
   rules:
     alertmanager: false
+kubeControllerManager:
+  enabled: {{ tools_cluster.provider == "kind" }}
 kubeEtcd:
-  enabled: "{{ tools_cluster.provider == 'kind' }}"
+  enabled: {{ tools_cluster.provider == "kind" }}
 kubeProxy:
-  enabled: "{{ tools_cluster.provider == 'kind' }}"
+  enabled: {{ tools_cluster.provider == "kind" }}
+kubeScheduler:
+  enabled: {{ tools_cluster.provider == "kind" }}


### PR DESCRIPTION
This PR disables a number of Kubernetes specific alerts which fire when using AWS clusters. Some of the issues with getting these metrics is described [here](https://github.com/prometheus-community/helm-charts/pull/6283). This also updates the otel-demo telemetry configuration to push to a different port.